### PR TITLE
Display Sidewalks Mapped on Roads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,8 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+
+# Local IDE settings
+
+.vscode

--- a/src/components/MainMap.tsx
+++ b/src/components/MainMap.tsx
@@ -102,11 +102,10 @@ export const MainMap = ({
             id="Paths"
             type="line"
             filter={[
-              "match",
+              "match", // https://docs.mapbox.com/style-spec/reference/expressions/#match
                 ["get", "highway"],
-                paths,
-                true,
-                false
+                paths, true, // return true if match found in array of recognized path values
+                false // return false as a fallback
               ]} // Filter for true paths
             paint={{
               "line-color": "red",
@@ -128,7 +127,7 @@ export const MainMap = ({
               "line-color": "red",
               "line-opacity": 0.8,
               "line-width": 2,
-              "line-dasharray": [1, 1 ],
+              "line-dasharray": [1, 1],
             }}
           />
         </Source>

--- a/src/components/MainMap.tsx
+++ b/src/components/MainMap.tsx
@@ -29,6 +29,7 @@ export const MainMap = ({
   const geolocateControlRef = useRef<any>(null);
   const router = useRouter();
   const [mapInstance, setMapInstance] = useState<MapboxMap>();
+  const paths = ["footway", "bridleway", "steps", "corridor", "path", "via_ferrata", "cycleway"];
 
   useEffect(() => {
     if (!mapInstance) return;
@@ -98,12 +99,36 @@ export const MainMap = ({
         <div ref={geocoderContainerRef} className="z-1 fixed top-2 right-12" />
         <Source type="geojson" data={sidewalkFeatureCollection}>
           <Layer
-            id="Data"
+            id="Paths"
             type="line"
+            filter={[
+              "match",
+                ["get", "highway"],
+                paths,
+                true,
+                false
+              ]} // Filter for true paths
             paint={{
               "line-color": "red",
               "line-opacity": 0.8,
               "line-width": 3,
+            }}
+          />
+          <Layer
+            id="Roads"
+            type="line"
+            filter={
+            ["match",
+                ["get", "highway"],
+                paths,
+                false,
+                true
+            ]} // Filter for non-paths (roads)
+            paint={{
+              "line-color": "red",
+              "line-opacity": 0.8,
+              "line-width": 2,
+              "line-dasharray": [1, 1 ],
             }}
           />
         </Source>

--- a/src/overpass/overpass.ts
+++ b/src/overpass/overpass.ts
@@ -12,6 +12,7 @@ export const overpassQuery = async (bounds: LngLatBounds) => {
       way[highway=steps];
       way[highway=path][foot=designated];
       way[highway=cycleway][foot=yes];
+      way["highway"~"^(motorway|trunk|primary|secondary|tertiary|unclassified|residential)?(_link)?$"]["sidewalk"~"^(both|left|right)?$"];
     )->.x1;
     nwr.x1->.result;
     (.result; - .done;)->.result;


### PR DESCRIPTION
## Summary:

This pull request implements changes to accurately display sidewalk infrastructure on OpenSidewalkMap:

1. Returning all sidewalks, regardless of whether they are mapped separately or as part of the road.

2. Separating the two kinds of data into two layers, with visually distinct styling:
- All sidewalks are rendered in red.
- Sidewalks mapped on roads are indicated by a single dashed line running down the center of the road.

## Future Considerations:

1. Adding a legend to indicate the styling of sidewalks.

2. Introducing user controls to toggle the visibility of each layer.

## References:
- addresses Issue #3: Display Sidewalk Infrastructure Accurately on OpenSidewalkMap